### PR TITLE
Need to avoid buffer underflow before adding '\0'

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -98,6 +98,8 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
     }
   }
 
+  // Make sure we have enough space to add '\0' character at end.
+  dec = (unsigned char *) realloc(dec, size);
   dec[size] = '\0';
   
   // Return back the size of decoded string if demanded.


### PR DESCRIPTION
Added fix to make sure we have enough space to add '\0' character at end.
