### PR TITLE
Added support for custom malloc functions

### DIFF
--- a/b64.h
+++ b/b64.h
@@ -15,7 +15,6 @@
 
 #ifndef b64_malloc
 #  define b64_malloc(ptr) malloc(ptr)
-#error
 #endif
 #ifndef b64_realloc
 #  define b64_realloc(ptr, size) realloc(ptr, size)

--- a/b64.h
+++ b/b64.h
@@ -9,6 +9,19 @@
 #define B64_H 1
 
 /**
+ *  Memory allocation functions to use. You can define b64_malloc and
+ * b64_realloc to custom functions if you want.
+ */
+
+#ifndef b64_malloc
+#  define b64_malloc(ptr) malloc(ptr)
+#error
+#endif
+#ifndef b64_realloc
+#  define b64_realloc(ptr, size) realloc(ptr, size)
+#endif
+
+/**
  * Base64 index table.
  */
 

--- a/decode.c
+++ b/decode.c
@@ -27,7 +27,7 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
   unsigned char tmp[4];
 
   // alloc
-  dec = (unsigned char *) malloc(0);
+  dec = (unsigned char *) b64_malloc(1);
   if (NULL == dec) { return NULL; }
 
   // parse until end of source
@@ -58,9 +58,13 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
       buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
 
       // write decoded buffer to `dec'
-      dec = (unsigned char *) realloc(dec, size + 3);
-      for (i = 0; i < 3; ++i) {
-        dec[size++] = buf[i];
+      dec = (unsigned char *) b64_realloc(dec, size + 3);
+      if (dec != NULL){
+        for (i = 0; i < 3; ++i) {
+          dec[size++] = buf[i];
+        }
+      } else {
+        return NULL;
       }
 
       // reset
@@ -92,18 +96,28 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
     buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
 
     // write remainer decoded buffer to `dec'
-    dec = (unsigned char *) realloc(dec, size + (i - 1));
-    for (j = 0; (j < i - 1); ++j) {
-      dec[size++] = buf[j];
+    dec = (unsigned char *) b64_realloc(dec, size + (i - 1));
+    if (dec != NULL){
+      for (j = 0; (j < i - 1); ++j) {
+        dec[size++] = buf[j];
+      }
+    } else {
+      return NULL;
     }
   }
 
   // Make sure we have enough space to add '\0' character at end.
-  dec = (unsigned char *) realloc(dec, size + 1);
-  dec[size] = '\0';
-  
+  dec = (unsigned char *) b64_realloc(dec, size + 1);
+  if (dec != NULL){
+    dec[size] = '\0';
+  } else {
+    return NULL;
+  }
+
   // Return back the size of decoded string if demanded.
-  if (decsize != NULL) *decsize = size;
-  
+  if (decsize != NULL) {
+    *decsize = size;
+  }
+
   return dec;
 }

--- a/encode.c
+++ b/encode.c
@@ -19,7 +19,7 @@ b64_encode (const unsigned char *src, size_t len) {
   unsigned char tmp[3];
 
   // alloc
-  enc = (char *) malloc(0);
+  enc = (char *) b64_malloc(1);
   if (NULL == enc) { return NULL; }
 
   // parse until end of source
@@ -38,7 +38,7 @@ b64_encode (const unsigned char *src, size_t len) {
       // then translate each encoded buffer
       // part by index from the base 64 index table
       // into `enc' unsigned char array
-      enc = (char *) realloc(enc, size + 4);
+      enc = (char *) b64_realloc(enc, size + 4);
       for (i = 0; i < 4; ++i) {
         enc[size++] = b64_table[buf[i]];
       }
@@ -63,20 +63,20 @@ b64_encode (const unsigned char *src, size_t len) {
 
     // perform same write to `enc` with new allocation
     for (j = 0; (j < i + 1); ++j) {
-      enc = (char *) realloc(enc, size + 1);
+      enc = (char *) b64_realloc(enc, size + 1);
       enc[size++] = b64_table[buf[j]];
     }
 
     // while there is still a remainder
     // append `=' to `enc'
     while ((i++ < 3)) {
-      enc = (char *) realloc(enc, size + 1);
+      enc = (char *) b64_realloc(enc, size + 1);
       enc[size++] = '=';
     }
   }
 
   // Make sure we have enough space to add '\0' character at end.
-  enc = (char *) realloc(enc, size + 1);
+  enc = (char *) b64_realloc(enc, size + 1);
   enc[size] = '\0';
 
   return enc;


### PR DESCRIPTION
On systems which have their own implementation of malloc, relaloc functions it is essential to be able to specify their names on compilation time without including extra header files. For example FreeRTOS have its own malloc (with different name). Another thing is that not always malloc allows for allocating zero bytes. 