### PR TITLE
Modified to use fixed-size buffers in processing.

### DIFF
--- a/b64.h
+++ b/b64.h
@@ -20,6 +20,17 @@
 #  define b64_realloc(ptr, size) realloc(ptr, size)
 #endif
 
+ // How much memory to allocate per buffer
+#define B64_BUFFER_SIZE		(1024 * 64) // 64K
+
+ // Start buffered memory
+char* b64_buf_malloc();
+
+// Update memory size. Returns the same pointer if we
+// have enough space in the buffer. Otherwise, we add
+// additional buffers.
+char* b64_buf_realloc(unsigned char* ptr, size_t size);
+
 /**
  * Base64 index table.
  */

--- a/buffer.c
+++ b/buffer.c
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+#include <ctype.h>
+#include "b64.h"
+
+#ifdef b64_USE_CUSTOM_MALLOC
+extern void* b64_malloc(size_t);
+#endif
+
+#ifdef b64_USE_CUSTOM_REALLOC
+extern void* b64_realloc(void*, size_t);
+#endif
+
+// The number of buffers we need
+int bufc = 0;
+
+char* b64_buf_malloc()
+{
+	char* buf = b64_malloc(B64_BUFFER_SIZE);
+	bufc = 1;
+	return buf;
+}
+
+char* b64_buf_realloc(unsigned char* ptr, size_t size)
+{
+	if (size > bufc * B64_BUFFER_SIZE)
+	{
+		while (size > bufc * B64_BUFFER_SIZE) bufc++;
+		char* buf = b64_realloc(ptr, B64_BUFFER_SIZE * bufc);
+		if (!buf) return NULL;
+		return buf;
+	}
+
+	return ptr;
+}

--- a/decode.c
+++ b/decode.c
@@ -34,7 +34,7 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
   unsigned char tmp[4];
 
   // alloc
-  dec = (unsigned char *) b64_malloc(1);
+  dec = (unsigned char *) b64_buf_malloc();
   if (NULL == dec) { return NULL; }
 
   // parse until end of source
@@ -65,7 +65,7 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
       buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
 
       // write decoded buffer to `dec'
-      dec = (unsigned char *) b64_realloc(dec, size + 3);
+      dec = (unsigned char *) b64_buf_realloc(dec, size + 3);
       if (dec != NULL){
         for (i = 0; i < 3; ++i) {
           dec[size++] = buf[i];
@@ -103,7 +103,7 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
     buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
 
     // write remainer decoded buffer to `dec'
-    dec = (unsigned char *) b64_realloc(dec, size + (i - 1));
+    dec = (unsigned char *)b64_buf_realloc(dec, size + (i - 1));
     if (dec != NULL){
       for (j = 0; (j < i - 1); ++j) {
         dec[size++] = buf[j];
@@ -114,7 +114,7 @@ b64_decode_ex (const char *src, size_t len, size_t *decsize) {
   }
 
   // Make sure we have enough space to add '\0' character at end.
-  dec = (unsigned char *) b64_realloc(dec, size + 1);
+  dec = (unsigned char *)b64_buf_realloc(dec, size + 1);
   if (dec != NULL){
     dec[size] = '\0';
   } else {

--- a/encode.c
+++ b/encode.c
@@ -27,7 +27,7 @@ b64_encode (const unsigned char *src, size_t len) {
   unsigned char tmp[3];
 
   // alloc
-  enc = (char *) b64_malloc(1);
+  enc = (char *) b64_buf_malloc();
   if (NULL == enc) { return NULL; }
 
   // parse until end of source
@@ -46,7 +46,7 @@ b64_encode (const unsigned char *src, size_t len) {
       // then translate each encoded buffer
       // part by index from the base 64 index table
       // into `enc' unsigned char array
-      enc = (char *) b64_realloc(enc, size + 4);
+      enc = (char *) b64_buf_realloc(enc, size + 4);
       for (i = 0; i < 4; ++i) {
         enc[size++] = b64_table[buf[i]];
       }
@@ -71,20 +71,20 @@ b64_encode (const unsigned char *src, size_t len) {
 
     // perform same write to `enc` with new allocation
     for (j = 0; (j < i + 1); ++j) {
-      enc = (char *) b64_realloc(enc, size + 1);
+      enc = (char *) b64_buf_realloc(enc, size + 1);
       enc[size++] = b64_table[buf[j]];
     }
 
     // while there is still a remainder
     // append `=' to `enc'
     while ((i++ < 3)) {
-      enc = (char *) b64_realloc(enc, size + 1);
+      enc = (char *) b64_buf_realloc(enc, size + 1);
       enc[size++] = '=';
     }
   }
 
   // Make sure we have enough space to add '\0' character at end.
-  enc = (char *) b64_realloc(enc, size + 1);
+  enc = (char *) b64_buf_realloc(enc, size + 1);
   enc[size] = '\0';
 
   return enc;


### PR DESCRIPTION
The should drastically reduce the calls to realloc.

Instead of growing by a tiny amount each time, it now increases memory allocation by a fixed amount. In effect, you have fixed-size buffers. Obviously, the functions are not suited to replace malloc/realloc but they should be fine for this specific case.