### PR TITLE
Update package config to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "b64",
-  "version": "0.0.1",
   "repo": "littlstar/b64.c",
+  "version": "0.0.2",
   "description": "Base64 encode/decode",
   "keywords": ["base", "64", "crypto"],
-  "src": ["b64.h", "encode.c", "decode.c"],
+  "src": ["b64.h", "encode.c", "decode.c", "buffer.c"],
   "development": { "jwerle/libok": "*" }
 }


### PR DESCRIPTION
Currently, when performing the clib install, the 0.0.1 tag is downloaded, which contains problems regarding the old realloc (prior to `b64_buf_realloc`)

Please, create tag 0.0.2 for current version